### PR TITLE
feat: startIcon & endIcon props for button

### DIFF
--- a/src/components/button/index.stories.tsx
+++ b/src/components/button/index.stories.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
-import { keys } from 'lodash'
+import { keys, isPlainObject } from 'lodash'
 import { action } from '@storybook/addon-actions'
 import { text, select, boolean, object } from '@storybook/addon-knobs'
 import { theme } from 'theme'
+import { Icon } from 'components'
+import { readableTextColor } from 'utils'
 import Button from './index'
 
 const metadata = {
@@ -82,6 +84,77 @@ export const Gradient = () => {
       loadingColor={loadingColor}
     >
       {value}
+    </Button>
+  )
+}
+
+export const WithIcon = () => {
+  const onClick = action('onClick')
+
+  const iconType = text('iconType', 'send')
+
+  const hasStartIcon = boolean('startIcon', false)
+
+  const hasEndIcon = boolean('endIcon', true)
+
+  const color = select('color', keys(theme.palette), 'primary')
+
+  const variant = select('variant', variants, 'contained')
+
+  const size = select('size', sizes, 'medium')
+
+  const disabled = boolean('disabled', false)
+
+  const fullWidth = boolean('fullWidth', false)
+
+  const loading = boolean('loading', false)
+
+  const disableRounded = boolean('disableRounded', false)
+
+  const disableElevation = boolean('disableElevation', false)
+
+  const iconVariant = variant === 'contained' ? 'filled' : 'outlined'
+
+  const hasGradiantText =
+    isPlainObject(color) && (variant === 'text' || variant === 'outlined')
+
+  const iconColor = hasGradiantText ? color : readableTextColor(color)
+
+  console.log('iconColor', iconColor)
+
+  return (
+    <Button
+      color={color}
+      disabled={disabled}
+      disableElevation={disableElevation}
+      disableRounded={disableRounded}
+      fullWidth={fullWidth}
+      loading={loading}
+      onClick={onClick}
+      size={size}
+      variant={variant}
+      startIcon={
+        hasStartIcon && (
+          <Icon
+            color={iconColor}
+            type={iconType}
+            variant={iconVariant}
+            size={20}
+          />
+        )
+      }
+      endIcon={
+        hasEndIcon && (
+          <Icon
+            color={iconColor}
+            type={iconType}
+            variant={iconVariant}
+            size={20}
+          />
+        )
+      }
+    >
+      {iconType}
     </Button>
   )
 }

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -12,16 +12,28 @@ interface ButtonProps {
   disabled?: boolean
   disableElevation?: boolean
   disableRounded?: boolean
+  endIcon?: ReactNode
   fullWidth?: boolean
   loading?: boolean
   loadingColor?: string
   onClick?: () => void
   size?: string
+  startIcon?: ReactNode
   variant?: string
 }
 
 const StyledBox = styled(props => <Box {...props} />)`
   visibility: hidden;
+
+  > :not(:last-child) {
+    margin-right: ${theme.spacing(1)};
+  }
+`
+
+const WithIconBox = styled(props => <Box {...props} />)`
+  > :not(:last-child) {
+    margin-right: ${theme.spacing(1)};
+  }
 `
 
 const resolveColor = (props: ButtonProps) => {
@@ -120,13 +132,13 @@ const resolveSize = (props: ButtonProps) => {
   const { size, variant } = props
 
   const smallFontSize = `
-    > * {
+    * {
       font-size: 18px !important;
     }
   `
 
   const largeFontSize = `
-    > * {
+    * {
       font-size: 22px !important;
     }
 `
@@ -195,7 +207,7 @@ const resolveDisabled = (props: ButtonProps) => {
     ${theme.boxShadow(0)}
    
 
-    > * {
+    * {
       color: ${theme.palette.textDisabled} !important;
       -webkit-text-fill-color: unset !important;
     }
@@ -288,7 +300,7 @@ const resolveVariant = (props: ButtonProps) => {
       padding: ${theme.spacing(0.75, 1)};
       ${theme.boxShadow(0)}
 
-      > * {
+      * {
         color: ${colorValue} !important;
       }
 
@@ -306,7 +318,7 @@ const resolveVariant = (props: ButtonProps) => {
       padding: ${theme.spacing(0.625, 1.875)};
       ${theme.boxShadow(0)}
 
-      > * {
+      * {
         color: ${colorValue} !important;
       }
 
@@ -353,11 +365,13 @@ const Button = (props: ButtonProps) => {
     disabled,
     disableElevation,
     disableRounded,
+    endIcon,
     fullWidth,
     loading,
     loadingColor,
     onClick,
     size,
+    startIcon,
     variant
   } = props
 
@@ -383,14 +397,48 @@ const Button = (props: ButtonProps) => {
     )
   }
 
+  const defaultContent = () => {
+    if (startIcon || endIcon) {
+      return (
+        <WithIconBox display="flex" center>
+          {startIcon && startIcon}
+          <Typography variant="h5" color={textColor}>
+            {toUpper(children)}
+          </Typography>
+          {endIcon && endIcon}
+        </WithIconBox>
+      )
+    }
+
+    return (
+      <Typography variant="h5" color={textColor}>
+        {toUpper(children)}
+      </Typography>
+    )
+  }
+
   const renderContent = () => {
     if (!isString(children)) {
       if (loading) {
         return (
           <>
-            <StyledBox>{children}</StyledBox>
+            <StyledBox>
+              {startIcon && startIcon}
+              {children}
+              {endIcon && endIcon}
+            </StyledBox>
             {renderLoading()}
           </>
+        )
+      }
+
+      if (startIcon || endIcon) {
+        return (
+          <WithIconBox>
+            {startIcon && startIcon}
+            {children}
+            {endIcon && endIcon}
+          </WithIconBox>
         )
       }
 
@@ -400,21 +448,13 @@ const Button = (props: ButtonProps) => {
     if (loading) {
       return (
         <>
-          <StyledBox>
-            <Typography variant="h5" color={textColor}>
-              {toUpper(children)}
-            </Typography>
-          </StyledBox>
+          <StyledBox>{defaultContent()}</StyledBox>
           {renderLoading()}
         </>
       )
     }
 
-    return (
-      <Typography variant="h5" color={textColor}>
-        {toUpper(children)}
-      </Typography>
-    )
+    return defaultContent()
   }
 
   return (
@@ -439,10 +479,12 @@ Button.defaultProps = {
   disabled: false,
   disableElevation: false,
   disableRounded: false,
+  endIcon: null,
   fullWidth: false,
   loading: false,
   onClick: null,
   size: 'medium',
+  startIcon: null,
   variant: 'contained'
 }
 

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -6,7 +6,7 @@ import { colorExists } from 'utils'
 
 interface IconProps {
   color?: any
-  size?: string
+  size?: string | number
   type?: string
   variant?: string
 }
@@ -55,21 +55,27 @@ const resolveSize = (props: IconProps) => {
     return ''
   }
 
+  if (typeof size === 'number') {
+    return `
+      font-size: ${size}px;
+    `
+  }
+
   if (size === 'small') {
     return `
-    font-size: 18px;
+      font-size: 18px;
     `
   }
 
   if (size === 'large') {
     return `
-    font-size: 36px;
+      font-size: 36px;
     `
   }
 
   if (size === 'extralarge') {
     return `
-    font-size: 48px;
+      font-size: 48px;
     `
   }
 


### PR DESCRIPTION
#### Problem statement ⚠️

...

#### Summary of changes ✍️

- [x] Add `startIcon` & `endIcon` props for `Button` component.
- [x] Add `WithIcon` story for `Button`.
- [x] `size` prop of `Icon` now acepts number to display a specific `font-size`.


#### Steps to test 🍻

...
